### PR TITLE
Update to edition 2018 & clippy + fmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/mikedilger/solvent"
 readme = "README.md"
 keywords = [ "dependency", "graph", "solver", "resolver" ]
 license = "MIT"
+edition = "2018"
 
 [lib]
 name = "solvent"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,7 @@
-
-use std::fmt;
 use std::error::Error;
+use std::fmt;
 
-#[derive(Clone,Debug,PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum SolventError {
     /// A cycle has been detected
     CycleDetected,
@@ -12,22 +11,10 @@ pub enum SolventError {
 impl fmt::Display for SolventError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            _ => self.description().fmt(f)
+            SolventError::CycleDetected => write!(f, "Cycle Detected"),
+            SolventError::NoSuchNode => write!(f, "No Such Node"),
         }
     }
 }
 
-impl Error for SolventError {
-    fn description(&self) -> &str
-    {
-        match *self {
-            SolventError::CycleDetected => "Cycle Detected",
-            SolventError::NoSuchNode => "No Such Node",
-        }
-    }
-    fn cause(&self) -> Option<&Error> {
-        match *self {
-            _ => None
-        }
-    }
-}
+impl Error for SolventError {}


### PR DESCRIPTION
A little facelift, update to 2018 edition and run clippy + rustfmt. Error type was updated to get rid of deprecations

Not sure if you're still active on this, the code hasn't been changed in some time, but here it is regardless.
