### PR TITLE
Add "indexmap" feature for deterministic order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,9 @@ path = "src/lib.rs"
 test = true
 doctest = true
 doc = true
+
+[dependencies]
+indexmap = { optional = true, version = "1.7.0" }
+
+[features]
+deterministic = [ "indexmap" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,11 @@
 pub mod error;
 pub use error::SolventError;
 
+#[cfg(feature = "deterministic")]
+use indexmap::{map::IndexMap as HashMap, set::IndexSet as HashSet};
+#[cfg(not(feature = "deterministic"))]
 use std::collections::{HashMap, HashSet};
+
 use std::iter::Iterator;
 
 /// This is the dependency graph. The type `T` is intended to be a small type, or a
@@ -263,8 +267,8 @@ impl<'a, T: Eq> Iterator for DepGraphIterator<'a, T> {
 #[cfg(test)]
 mod test {
     use super::DepGraph;
+    use super::HashSet;
     use super::SolventError;
-    use std::collections::HashSet;
 
     #[test]
     fn solvent_test_branching() {


### PR DESCRIPTION
This PR allows to optionally use IndexMap and IndexSet from [indexmap](https://docs.rs/indexmap/1.7.0/indexmap/) for order-preserving drop-in replacements for HashMap and HashSet.

If I understand the used algorithm correctly, this makes the output of solvent deterministic. (it does for the example. :innocent:).

As indexmap would add an dependency, and might be a tad slower in benchmarks, this is guarded by the non-default feature "deterministic".